### PR TITLE
make getAllWords public

### DIFF
--- a/app/src/main/java/com/example/android/roomwordssample/WordRepository.java
+++ b/app/src/main/java/com/example/android/roomwordssample/WordRepository.java
@@ -44,7 +44,7 @@ public class WordRepository {
 
     // Room executes all queries on a separate thread.
     // Observed LiveData will notify the observer when the data has changed.
-    LiveData<List<Word>> getAllWords() {
+    public LiveData<List<Word>> getAllWords() {
         return mAllWords;
     }
 


### PR DESCRIPTION
The method is used inside the ViewModel, it should be public to be accessed.