### PR TITLE
Correcting InsertAsyncTask Class Name in `WordRepository`

### DIFF
--- a/app/src/main/java/com/example/android/roomwordssample/WordRepository.java
+++ b/app/src/main/java/com/example/android/roomwordssample/WordRepository.java
@@ -52,14 +52,14 @@ class WordRepository {
     // Like this, Room ensures that you're not doing any long running operations on the main
     // thread, blocking the UI.
     void insert(Word word) {
-        new insertAsyncTask(mWordDao).execute(word);
+        new InsertAsyncTask(mWordDao).execute(word);
     }
 
-    private static class insertAsyncTask extends AsyncTask<Word, Void, Void> {
+    private static class InsertAsyncTask extends AsyncTask<Word, Void, Void> {
 
         private WordDao mAsyncTaskDao;
 
-        insertAsyncTask(WordDao dao) {
+        InsertAsyncTask(WordDao dao) {
             mAsyncTaskDao = dao;
         }
 


### PR DESCRIPTION
#### Issue

The guide for [creating a Repository](https://codelabs.developers.google.com/codelabs/android-room-with-a-view/#7) references code that uses incorrect Java naming conventions.
_(ubiquitous, but for reference:  [Google Style Guide for Class Names](https://google.github.io/styleguide/javaguide.html#s5.2.2-class-names))_

#### Resolution

The declaration and use of `insertAsyncTask` has been corrected to use Upper Camel Case.

- The only references and usages I can find are all in the `WordRepository` class, so the inner class declaration, constructor, and single usage has been corrected.