### PR TITLE
Bump up the dependency for appCompatVersion to fix ViewModel instance creation crash.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    appCompatVersion = '1.2.0'
+    appCompatVersion = '1.3.0-rc01'
     constraintLayoutVersion = '2.0.2'
     coreTestingVersion = '2.1.0'
     lifecycleVersion = '2.2.0'


### PR DESCRIPTION
Somehow Lifecycle 2.2.0 version of `AppCompatActivity` does not have `HasDefaultViewModelProviderFactory` which is causing issues for all viewModels extending AndroidViewModel.

Some more discussion is [here](https://stackoverflow.com/questions/60451458/possible-to-access-androidviewmodel-of-activity-via-fragment/60451554#60451554). Apparently, the new version fixes it. 